### PR TITLE
docs(readme): bump example usage to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # change-milestone-action
+
 Change an existing milestone. Pure JS action.
 
 The action is written in JavaScript for speed of execution.
@@ -66,7 +67,7 @@ The due date of the changed milestone.
 ## Example
 
 ```yaml
-uses: sv-tools/change-milestone-action@v1
+uses: sv-tools/change-milestone-action@v2
 with:
   token: ${{ secrets.GITHUB_TOKEN }}
   by_id: "123"


### PR DESCRIPTION
Update README example to reference the v2 release tag for the
sv-tools/change-milestone-action. This clarifies the action
version and ensures examples reflect the current released major, helping
users avoid accidentally using an outdated v1 tag.