### PR TITLE
chore(ci): pin GitHub Actions to specific SHAs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,7 +20,7 @@ jobs:
   Check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5.0.0 # immutable action, safe to use a version instead of hashtag
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - run: npm install
       - run: npm run check
 
@@ -29,10 +29,10 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/checkout@v5.0.0 # immutable action, safe to use a version instead of hashtag
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Create Milestone
         id: create
-        uses: sv-tools/create-milestone-action@v2.0.0
+        uses: sv-tools/create-milestone-action@b13d071df1877ae13c83e9e3c796857575a38315 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           title: ${{ github.run_number }}
@@ -65,7 +65,7 @@ jobs:
           state: "closed"
       - run: echo "changed by Title - ${{ steps.change-by-title.outputs.description }}, state ${{ steps.change-by-title.outputs.state }}"
       - name: Delete Milestone
-        uses: octokit/request-action@v2.x
+        uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d # v2.4.0
         with:
           route: DELETE /repos/${{ github.repository }}/milestones/${{ steps.create.outputs.number }}
         env:

--- a/.github/workflows/update-dist.yml
+++ b/.github/workflows/update-dist.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5.0.0 # immutable action
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - run: npm install
       - run: npm run all
       - name: Checking Git


### PR DESCRIPTION
Pin actions/checkout and sv-tools/create-milestone-action steps to
immutable commit SHAs instead of loose version tags. This ensures the
CI workflows use exact revisions, preventing unexpected changes
from upstream action updates and improving reproducibility for CI
runs and releases.